### PR TITLE
Change list() to listTimeZone()

### DIFF
--- a/src/TimeZoneDB.php
+++ b/src/TimeZoneDB.php
@@ -38,7 +38,7 @@ class TimeZoneDB
      * @param  array  $options Request params
      * @return \NNV\TimeZoneDB::execute
      */
-    public function list(array $options = [])
+    public function listTimeZone(array $options = [])
     {
         $options = $this->validateListParams($options);
 


### PR DESCRIPTION
Change `list()` to `listTimeZone()` to prevent `syntax error, unexpected 'list' (T_LIST), expecting identifier (T_STRING)` in PHP5